### PR TITLE
fix: don't map error frames for node_modules

### DIFF
--- a/src/error-listener/mapper.ts
+++ b/src/error-listener/mapper.ts
@@ -73,28 +73,24 @@ async function map(bundler: Bundler, frames: StackFrame[], contextLines: number 
     const { map, fileSource, filepath } = cache[fileName] || {};
 
     // File not known to sandpack, returning original frame
-    if (!filepath || lineNumber == null || columnNumber == null) {
+    if (!filepath || lineNumber == null || columnNumber == null || filepath.includes('node_modules')) {
       return frame;
     }
 
     // There is no map we assume the positions are correct
     if (map == null) {
-      if (filepath.includes('node_modules')) {
-        return frame;
-      } else {
-        return new StackFrame(
-          functionName,
-          fileName,
-          lineNumber,
-          columnNumber,
-          getLinesAround(lineNumber, contextLines, fileSource),
-          functionName,
-          filepath,
-          lineNumber,
-          columnNumber,
-          getLinesAround(lineNumber, contextLines, fileSource)
-        );
-      }
+      return new StackFrame(
+        functionName,
+        fileName,
+        lineNumber,
+        columnNumber,
+        getLinesAround(lineNumber, contextLines, fileSource),
+        functionName,
+        filepath,
+        lineNumber,
+        columnNumber,
+        getLinesAround(lineNumber, contextLines, fileSource)
+      );
     }
 
     // There is a sourcemap so we map to the original position

--- a/src/error-listener/mapper.ts
+++ b/src/error-listener/mapper.ts
@@ -79,18 +79,22 @@ async function map(bundler: Bundler, frames: StackFrame[], contextLines: number 
 
     // There is no map we assume the positions are correct
     if (map == null) {
-      return new StackFrame(
-        functionName,
-        fileName,
-        lineNumber,
-        columnNumber,
-        getLinesAround(lineNumber, contextLines, fileSource),
-        functionName,
-        filepath,
-        lineNumber,
-        columnNumber,
-        getLinesAround(lineNumber, contextLines, fileSource)
-      );
+      if (filepath.includes('node_modules')) {
+        return frame;
+      } else {
+        return new StackFrame(
+          functionName,
+          fileName,
+          lineNumber,
+          columnNumber,
+          getLinesAround(lineNumber, contextLines, fileSource),
+          functionName,
+          filepath,
+          lineNumber,
+          columnNumber,
+          getLinesAround(lineNumber, contextLines, fileSource)
+        );
+      }
     }
 
     // There is a sourcemap so we map to the original position

--- a/src/error-listener/mapper.ts
+++ b/src/error-listener/mapper.ts
@@ -40,14 +40,8 @@ async function map(bundler: Bundler, frames: StackFrame[], contextLines: number 
   await settle(
     Array.from(fileNames).map(async (fileName) => {
       if (!fileName.startsWith('webpack')) {
-        // TODO: In case we ever support query parameters
-        // if (fileName.includes('?')) {
-        //   transpiledModule = manager.getTranspiledModuleByHash(
-        //     fileName.split('?')[1]
-        //   );
-        // }
-
-        const resolvedFilepath = await bundler.resolveAsync(fileName.replace(location.origin, ''), '/index.js');
+        const parsedUrl = new URL(fileName, location.origin);
+        const resolvedFilepath = await bundler.resolveAsync(parsedUrl.pathname, '/index.js');
         const foundModule = bundler.getModule(resolvedFilepath);
 
         if (foundModule) {


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack-bundler/fix/no_node_module_mapping">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack-bundler&branch=fix/no_node_module_mapping">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

Don't map error frames for node_modules