### PR TITLE
Bug fix: multiple file resolvers

### DIFF
--- a/src/FileSystem/layers/IFrameFSLayer.ts
+++ b/src/FileSystem/layers/IFrameFSLayer.ts
@@ -5,9 +5,16 @@ import { MemoryFSLayer } from './MemoryFSLayer';
 export class IFrameFSLayer extends FSLayer {
   private isBypassed = true;
   private isFileCache: Map<string, boolean> = new Map();
+  private getFileResolverId: () => string | undefined;
 
-  constructor(private memoryFS: MemoryFSLayer, private messageBus: IFrameParentMessageBus) {
+  constructor(
+    private memoryFS: MemoryFSLayer,
+    private messageBus: IFrameParentMessageBus,
+    getFileResolverId: () => string | undefined
+  ) {
     super('iframe-fs');
+
+    this.getFileResolverId = getFileResolverId;
   }
 
   enableIFrameFS(): void {
@@ -44,6 +51,7 @@ export class IFrameFSLayer extends FSLayer {
           const response = await this.messageBus.protocolRequest('file-resolver', {
             m: 'readFile',
             p: path,
+            id: this.getFileResolverId(),
           });
           if (typeof response === 'string') {
             return response;

--- a/src/FileSystem/layers/IFrameFSLayer.ts
+++ b/src/FileSystem/layers/IFrameFSLayer.ts
@@ -5,16 +5,15 @@ import { MemoryFSLayer } from './MemoryFSLayer';
 export class IFrameFSLayer extends FSLayer {
   private isBypassed = true;
   private isFileCache: Map<string, boolean> = new Map();
-  private getFileResolverId: () => string | undefined;
+  private getClientId: () => string | undefined;
 
   constructor(
     private memoryFS: MemoryFSLayer,
     private messageBus: IFrameParentMessageBus,
-    getFileResolverId: () => string | undefined
+    getClientId: () => string | undefined
   ) {
     super('iframe-fs');
-
-    this.getFileResolverId = getFileResolverId;
+    this.getClientId = getClientId;
   }
 
   enableIFrameFS(): void {
@@ -51,8 +50,9 @@ export class IFrameFSLayer extends FSLayer {
           const response = await this.messageBus.protocolRequest('file-resolver', {
             m: 'readFile',
             p: path,
-            id: this.getFileResolverId(),
+            id: this.getClientId(),
           });
+
           if (typeof response === 'string') {
             return response;
           }

--- a/src/bundler/bundler.ts
+++ b/src/bundler/bundler.ts
@@ -52,14 +52,19 @@ export class Bundler {
 
   private _previousDepString: string | null = null;
   private iFrameFsLayer: IFrameFSLayer;
+  private fileResolverId: string | undefined;
 
   constructor(options: IBundlerOpts) {
     this.transformationQueue = new NamedPromiseQueue(true, 50);
     this.moduleRegistry = new ModuleRegistry(this);
     const memoryFS = new MemoryFSLayer();
-    this.iFrameFsLayer = new IFrameFSLayer(memoryFS, options.messageBus);
+    this.iFrameFsLayer = new IFrameFSLayer(memoryFS, options.messageBus, () => this.fileResolverId);
     this.fs = new FileSystem([memoryFS, this.iFrameFsLayer, new NodeModuleFSLayer(this.moduleRegistry)]);
     this.messageBus = options.messageBus;
+  }
+
+  setFileResolverId(id: string): void {
+    this.fileResolverId = id;
   }
 
   /** Reset all compilation data */

--- a/src/bundler/bundler.ts
+++ b/src/bundler/bundler.ts
@@ -52,19 +52,19 @@ export class Bundler {
 
   private _previousDepString: string | null = null;
   private iFrameFsLayer: IFrameFSLayer;
-  private fileResolverId: string | undefined;
+  private clientId: string | undefined;
 
   constructor(options: IBundlerOpts) {
     this.transformationQueue = new NamedPromiseQueue(true, 50);
     this.moduleRegistry = new ModuleRegistry(this);
     const memoryFS = new MemoryFSLayer();
-    this.iFrameFsLayer = new IFrameFSLayer(memoryFS, options.messageBus, () => this.fileResolverId);
+    this.iFrameFsLayer = new IFrameFSLayer(memoryFS, options.messageBus, () => this.clientId);
     this.fs = new FileSystem([memoryFS, this.iFrameFsLayer, new NodeModuleFSLayer(this.moduleRegistry)]);
     this.messageBus = options.messageBus;
   }
 
-  setFileResolverId(id: string): void {
-    this.fileResolverId = id;
+  setClientId(id: string): void {
+    this.clientId = id;
   }
 
   /** Reset all compilation data */

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,8 +123,8 @@ class SandpackInstance {
      * TODO: register file resolver id
      * Does it have a better approach for it?
      */
-    if (compileRequest.fileResolver) {
-      this.bundler.setFileResolverId(compileRequest.fileResolver.id);
+    if (compileRequest.clientId) {
+      this.bundler.setClientId(compileRequest.clientId);
     }
 
     this.messageBus.sendMessage('start', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,14 @@ class SandpackInstance {
       hasAsyncFileResolver: compileRequest.hasFileResolver,
     });
 
+    /**
+     * TODO: register file resolver id
+     * Does it have a better approach for it?
+     */
+    if (compileRequest.fileResolver) {
+      this.bundler.setFileResolverId(compileRequest.fileResolver.id);
+    }
+
     this.messageBus.sendMessage('start', {
       firstLoad: this.bundler.isFirstLoad,
     });

--- a/src/protocol/message-types.ts
+++ b/src/protocol/message-types.ts
@@ -17,11 +17,7 @@ export interface ICompileRequest {
   showOpenInCodeSandbox?: boolean;
   skipEval?: boolean;
   logLevel?: SandpackLogLevel;
-  fileResolver?: {
-    id: string;
-    isFile: (path: string) => Promise<boolean>;
-    readFile: (path: string) => Promise<string>;
-  };
+  clientId?: string;
 }
 
 export type BundlerStatus =

--- a/src/protocol/message-types.ts
+++ b/src/protocol/message-types.ts
@@ -17,6 +17,11 @@ export interface ICompileRequest {
   showOpenInCodeSandbox?: boolean;
   skipEval?: boolean;
   logLevel?: SandpackLogLevel;
+  fileResolver?: {
+    id: string;
+    isFile: (path: string) => Promise<boolean>;
+    readFile: (path: string) => Promise<string>;
+  };
 }
 
 export type BundlerStatus =


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack-bundler/draft/elated-oskar">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack-bundler&branch=draft/elated-oskar">VS Code</a>

---

Depends on https://github.com/codesandbox/sandpack/pull/476

<!-- codesandbox/open-in-codesandbox:complete -->
First sandbox should render File A and the second one File B
![Screenshot 2022-05-26 at 15 13 54](https://user-images.githubusercontent.com/4838076/170505603-cd3808d8-db95-4f63-96b9-efeee8cb618f.png)

😢 
![Screenshot 2022-05-26 at 16 06 55](https://user-images.githubusercontent.com/4838076/170516876-7db78826-ed89-406c-a76c-56b0e1a204ad.png)

