### PR TITLE
Bug report: can't resolve files with a level above

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -23,7 +23,7 @@
     },
     "test": {
       "name": "test",
-      "command": "yarn test",
+      "command": "yarn test --watch",
       "runAtStart": true
     }
   }

--- a/src/resolver/resolver.test.ts
+++ b/src/resolver/resolver.test.ts
@@ -37,6 +37,17 @@ describe('resolve', () => {
   });
 
   describe('file paths', () => {
+    it('should resolve relative file a level above', () => {
+      const resolved = resolveSync('../components', {
+        filename: '/app/index.js',
+        extensions: ['.js', '.tsx'],
+        isFile,
+        readFile,
+      });
+
+      expect(resolved).toBe('/src/components/index.js');
+    });
+
     it('should resolve relative file with an extension', () => {
       const resolved = resolveSync('../source/dist.js', {
         filename: '/packages/source-alias/other.js',

--- a/src/resolver/resolver.test.ts
+++ b/src/resolver/resolver.test.ts
@@ -39,13 +39,13 @@ describe('resolve', () => {
   describe('file paths', () => {
     it('should resolve relative file a level above', () => {
       const resolved = resolveSync('../components', {
-        filename: '/app/index.js',
+        filename: '/src/app/index.js',
         extensions: ['.js', '.tsx'],
         isFile,
         readFile,
       });
 
-      expect(resolved).toBe('/src/components/index.js');
+      expect(resolved).toBe('/src/components/index.tsx');
     });
 
     it('should resolve relative file with an extension', () => {


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/sandpack-bundler/draft/silly-bash">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=sandpack-bundler&branch=draft/silly-bash">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

I was working on some sandboxes on Redux repository, and I noted that the bundler is not resolving a few paths, for example:

```js
// /actions/index.js
File content

// /container/App.js
import { } from '../actions' // doesn't work
import { } from '../actions/index.js' // works
```

So, I tried to reproduce this scenario into an unit test, hope it makes sense.