### PR TITLE
chore: update cdn version

### DIFF
--- a/src/bundler/module-registry/module-cdn.ts
+++ b/src/bundler/module-registry/module-cdn.ts
@@ -14,7 +14,7 @@ export interface IResolvedDependency {
   d: number;
 }
 
-const CDN_VERSION = 3;
+const CDN_VERSION = 4;
 
 function encodePayload(payload: string): string {
   return btoa(`${CDN_VERSION}(${payload})`);


### PR DESCRIPTION
New cdn version includes a fix for caching the cors headers