### PR TITLE
feat: Use msgpack to communicate with the CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "browserslist": "> 2.5%, not ie 11, not dead, not op_mini all",
   "dependencies": {
     "@babel/standalone": "7.18.4",
+    "@msgpack/msgpack": "^2.8.0",
     "@swc/helpers": "^0.3.8",
     "@types/babel__standalone": "7.1.4",
     "babel-preset-solid": "^1.3.13",

--- a/src/bundler/module-registry/module-cdn.ts
+++ b/src/bundler/module-registry/module-cdn.ts
@@ -15,7 +15,7 @@ export interface IResolvedDependency {
   d: number;
 }
 
-const CDN_VERSION = 4;
+const CDN_VERSION = 5;
 
 function encodePayload(payload: string): string {
   return btoa(`${CDN_VERSION}(${payload})`);

--- a/src/bundler/module-registry/module-cdn.ts
+++ b/src/bundler/module-registry/module-cdn.ts
@@ -1,3 +1,4 @@
+import { decode as decodeMsgPack } from '@msgpack/msgpack';
 import urlJoin from 'url-join';
 
 import { retryFetch } from '../../utils/fetch';
@@ -26,7 +27,8 @@ export async function fetchManifest(deps: DepMap): Promise<IResolvedDependency[]
     maxRetries: 5,
     retryDelay: 1000,
   });
-  return result.json();
+  const buffer = await result.arrayBuffer();
+  return decodeMsgPack(buffer) as IResolvedDependency[];
 }
 
 export type CDNModuleFileType = ICDNModuleFile | number;
@@ -51,5 +53,6 @@ export async function fetchModule(name: string, version: string): Promise<ICDNMo
   const specifier = `${name}@${version}`;
   const encoded_specifier = encodePayload(specifier);
   const result = await retryFetch(urlJoin(CDN_ROOT, `/package/${encoded_specifier}`), { maxRetries: 5 });
-  return result.json();
+  const buffer = await result.arrayBuffer();
+  return decodeMsgPack(buffer) as ICDNModule;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,6 +1633,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@msgpack/msgpack@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.8.0.tgz#4210deb771ee3912964f14a15ddfb5ff877e70b9"
+  integrity sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==
+
 "@node-rs/xxhash-android-arm-eabi@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@node-rs/xxhash-android-arm-eabi/-/xxhash-android-arm-eabi-1.2.0.tgz#b4073411ec05630b7963275762b13928e2d4d0a2"


### PR DESCRIPTION
Uses msgpack for messages in sandpack cdn

Does this make sense, or should we scrap the versions idea in the cdn and use /msgpack as a suffix or something instead?

I've also been thinking of removing the versions idea for the v2 endpoints entirely, but not sure about it
