### PR TITLE
fix: send done message when bundler has finished 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -225,7 +225,7 @@ class SandpackInstance {
     }
 
     logger.debug(logger.logFactory('Finished', `in ${Date.now() - bundlerStartTime}ms`));
-    this.messageBus.sendMessage('status', { status: 'idle' });
+    this.messageBus.sendMessage('status', { status: 'done' });
   }
 
   dispose() {


### PR DESCRIPTION
Changed the status message from 'idle' to 'done'

Closes https://github.com/codesandbox/sandpack-bundler/issues/61